### PR TITLE
Project can be installed as dependcy via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,25 @@ Try the task and see your score at
 
 ## Installation
 
+You can install this library directly from GitHub using pip:
+
+```bash
+pip install git+https://github.com/jayolson/divergent-association-task.git
+```
+
+Download and extract the GloVe model file (`glove.840B.300d.zip`) from <https://nlp.stanford.edu/projects/glove/> and place it in your project directory.
+
+Alternatively, you can install manually by following these steps:
+
 1. Clone this code:
-
     - `git clone https://github.com/jayolson/divergent-association-task.git`
-
 2. Install [Python 3](https://www.python.org) and [pip](https://pypi.org/project/pip/).
-
 3. Download the dependencies and model:
-
     - `make install` on Unix-like systems
-
     - or else:
-
         - `pip3 install --user numpy scipy`
-
         - Download and extract glove.840B.300d.zip from <https://nlp.stanford.edu/projects/glove/>
-
 4. Try it:
-
     - `python3 examples.py`
 
 ## Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "divergent-association-task"
+version = "0.1.0"
+description = "Compute score for Divergent Association Task, a quick and simple measure of creativity."
+authors = [
+    { name = "Jay Olson" }
+]
+license = { file = "LICENSE.txt" }
+readme = "README.md"
+requires-python = ">=3.7"
+dependencies = [
+    "numpy",
+    "scipy"
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"
+]
+
+[project.urls]
+Homepage = "https://github.com/jayolson/divergent-association-task"
+
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Add pyproject.toml and convert repo into a python model. This allows the repo to be defined as dependecy in other python projects.

The project can now be installed via `pip install git+https://github.com/jayolson/divergent-association-task.git`

Updated README.md to reflect new installation method 